### PR TITLE
feat(VolumeMapper): skip viewport bounds calc

### DIFF
--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -63,6 +63,10 @@ const DEFAULT_VALUES = {
   autoAdjustSampleDistances: true,
   blendMode: BlendMode.COMPOSITE_BLEND,
   averageIPScalarRange: [-1000000.0, 1000000.0],
+
+  // If the camera goes inside the volume, coordinate transformation behind the camera fails, then the rendering will not be correct.
+  // So if you want to skip the calculation of the viewport bounds of the volume, please set useViewportBoundsOfVolume to false.
+  useViewportBoundsOfVolume: true,
 };
 
 // ----------------------------------------------------------------------------
@@ -82,6 +86,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'maximumSamplesPerRay',
     'autoAdjustSampleDistances',
     'blendMode',
+    'useViewportBoundsOfVolume',
   ]);
 
   macro.setGetArray(publicAPI, model, ['averageIPScalarRange'], 2);

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -587,32 +587,34 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     let dcymin = 1.0;
     let dcymax = -1.0;
 
-    for (let i = 0; i < 8; ++i) {
-      vec3.set(
-        pos,
-        bounds[i % 2],
-        bounds[2 + (Math.floor(i / 2) % 2)],
-        bounds[4 + Math.floor(i / 4)]
-      );
-      vec3.transformMat4(pos, pos, model.modelToView);
-      if (!cam.getParallelProjection()) {
-        vec3.normalize(dir, pos);
+    if (model.renderable.getUseViewportBoundsOfVolume()) {
+      for (let i = 0; i < 8; ++i) {
+        vec3.set(
+          pos,
+          bounds[i % 2],
+          bounds[2 + (Math.floor(i / 2) % 2)],
+          bounds[4 + Math.floor(i / 4)]
+        );
+        vec3.transformMat4(pos, pos, model.modelToView);
+        if (!cam.getParallelProjection()) {
+          vec3.normalize(dir, pos);
 
-        // now find the projection of this point onto a
-        // nearZ distance plane. Since the camera is at 0,0,0
-        // in VC the ray is just t*pos and
-        // t is -nearZ/dir.z
-        // intersection becomes pos.x/pos.z
-        const t = -crange[0] / pos[2];
-        vec3.scale(pos, dir, t);
+          // now find the projection of this point onto a
+          // nearZ distance plane. Since the camera is at 0,0,0
+          // in VC the ray is just t*pos and
+          // t is -nearZ/dir.z
+          // intersection becomes pos.x/pos.z
+          const t = -crange[0] / pos[2];
+          vec3.scale(pos, dir, t);
+        }
+        // now convert to DC
+        vec3.transformMat4(pos, pos, keyMats.vcpc);
+
+        dcxmin = Math.min(pos[0], dcxmin);
+        dcxmax = Math.max(pos[0], dcxmax);
+        dcymin = Math.min(pos[1], dcymin);
+        dcymax = Math.max(pos[1], dcymax);
       }
-      // now convert to DC
-      vec3.transformMat4(pos, pos, keyMats.vcpc);
-
-      dcxmin = Math.min(pos[0], dcxmin);
-      dcxmax = Math.max(pos[0], dcxmax);
-      dcymin = Math.min(pos[1], dcymin);
-      dcymax = Math.max(pos[1], dcymax);
     }
 
     program.setUniformf('dcxmin', dcxmin);


### PR DESCRIPTION
If the camera goes inside the volume, coordinate transformation behind the camera fails, then the rendering will not be correct.
So we modified to skip the calculation of the viewport bounds of the volume if useViewportBoundsOfVolume = false.